### PR TITLE
new function for toggling between different show modes

### DIFF
--- a/contextmenu_folder.js
+++ b/contextmenu_folder.js
@@ -911,6 +911,7 @@ function plugin_contextmenu_folder() {
 		'show_all', //
 		'show_active', //
 		'show_favorite', //
+		'toggle_show_mode', //
 
 		'reset_selected', //
 		'reset_transient', //
@@ -2021,6 +2022,19 @@ plugin_contextmenu_folder.prototype.show_active = function show_active() {
 plugin_contextmenu_folder.prototype.show_favorite = function show_favorite() {
 	var self = this;
 	self.show_mode('show_favorite');
+}
+
+// plugin command
+plugin_contextmenu_folder.prototype.toggle_show_mode = function toggle_show_mode() {
+	var self = this;
+	var show_mode = self.env('show_mode');
+	if (show_mode == 'show_all') { 
+		self.show_mode('show_favorite'); 
+	} else if (show_mode == 'show_favorite') { 
+		self.show_mode('show_active'); 
+	} else { 
+		self.show_mode('show_all'); 
+	}
 }
 
 // command provider


### PR DESCRIPTION
Hi, I'm using a keyboard shortcut plugin for roundcube. Instead of adding three different shortcuts for the show modes (show_all, show_active, show_favorite) I would prefer a single shortcut for toggling between the different modes. This is much more convenient. Therefore I have added a respective function to your plugin (toggle_show_mode). This function does not affect any other stuff of the plugin. Would be great if you could merge it :-) Thanks!